### PR TITLE
JWT Authentication fixes

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -109,7 +109,7 @@ class ShibbolethController extends Controller
 
         $route = config('shibboleth.authenticated');
 
-        if (config('jwtauth') === true) {
+        if (config('shibboleth.jwtauth') === true) {
             $route .= $this->tokenizeRedirect($user, ['auth_type' => 'idp']);
         }
 
@@ -124,7 +124,7 @@ class ShibbolethController extends Controller
         Auth::logout();
         Session::flush();
 
-        if (config('jwtauth')) {
+        if (config('shibboleth.jwtauth')) {
             $token = JWTAuth::parseToken();
             $token->invalidate();
         }

--- a/src/StudentAffairsUwm/Shibboleth/ShibbolethServiceProvider.php
+++ b/src/StudentAffairsUwm/Shibboleth/ShibbolethServiceProvider.php
@@ -28,7 +28,7 @@ class ShibbolethServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if (config('jwtauth')) {
+        if (config('shibboleth.jwtauth')) {
             $this->app->register('Tymon\JWTAuth\Providers\JWTAuthServiceProvider');
             $loader = AliasLoader::getInstance();
             $loader->alias('JWTAuth', 'Tymon\JWTAuth\Facades\JWTAuth');

--- a/src/StudentAffairsUwm/Shibboleth/ShibbolethServiceProvider.php
+++ b/src/StudentAffairsUwm/Shibboleth/ShibbolethServiceProvider.php
@@ -29,7 +29,7 @@ class ShibbolethServiceProvider extends ServiceProvider
     public function register()
     {
         if (config('shibboleth.jwtauth')) {
-            $this->app->register('Tymon\JWTAuth\Providers\JWTAuthServiceProvider');
+            $this->app->register('Tymon\JWTAuth\Providers\LaravelServiceProvider');
             $loader = AliasLoader::getInstance();
             $loader->alias('JWTAuth', 'Tymon\JWTAuth\Facades\JWTAuth');
             $loader->alias('JWTFactory', 'Tymon\JWTAuth\Facades\JWTFactory');


### PR DESCRIPTION
Changes:

1. Use correct config key defined within the `shibboleth.php` configuration file.
2. Register correct service provider as described on [https://jwt-auth.readthedocs.io/en/develop/laravel-installation/](https://jwt-auth.readthedocs.io/en/develop/laravel-installation/).