### PR TITLE
Move the Shibalike idpUrl into a config setting

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -89,8 +89,10 @@ class ShibbolethController extends Controller
 
         // Attempt to login with the email, if success, update the user model
         // with data from the Shibboleth headers (if present)
-        if (Auth::attempt(array('email' => $map['email']), true)) {
-            $user = $userClass::where('email', '=', $map['email'])->first();
+        //if (Auth::attempt(array(config('shibboleth.authentication_field_shibboleth', 'email') => $map[]), true)) {
+        $authenticationField = config('shibboleth.user_authentication_field', 'email');
+        if (Auth::attempt(array($authenticationField => $map[$authenticationField]), true)) {
+            $user = $userClass::where($authenticationField, '=', $map[$authenticationField])->first();
 
             // Update the model as necessary
             $user->update($map);

--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -38,7 +38,7 @@ class ShibbolethController extends Controller
     {
         if (config('shibboleth.emulate_idp') === true) {
             $this->config = new \Shibalike\Config();
-            $this->config->idpUrl = config('app.url', '') . '/emulated/idp';
+            $this->config->idpUrl = config('shibboleth.emulate_idp_url', '/emulated/idp');
 
             $stateManager = $this->getStateManager();
 

--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -38,7 +38,7 @@ class ShibbolethController extends Controller
     {
         if (config('shibboleth.emulate_idp') === true) {
             $this->config = new \Shibalike\Config();
-            $this->config->idpUrl = '/emulated/idp';
+            $this->config->idpUrl = config('url', '') . '/emulated/idp'; 
 
             $stateManager = $this->getStateManager();
 

--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -38,7 +38,7 @@ class ShibbolethController extends Controller
     {
         if (config('shibboleth.emulate_idp') === true) {
             $this->config = new \Shibalike\Config();
-            $this->config->idpUrl = config('url', '') . '/emulated/idp'; 
+            $this->config->idpUrl = config('app.url', '') . '/emulated/idp';
 
             $stateManager = $this->getStateManager();
 

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -15,6 +15,7 @@ return [
     'idp_logout' => '/Shibboleth.sso/Logout',
     'authenticated' => '/',
 
+
     /*
     |--------------------------------------------------------------------------
     | Emulate an IdP
@@ -75,6 +76,9 @@ return [
         'email' => 'Shib-mail',
         'emplid' => 'Shib-emplId',
     ],
+
+    //Which fields should we match against for identifying users
+    'user_authentication_field' => 'email',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -31,6 +31,7 @@ return [
      */
 
     'emulate_idp' => env('EMULATE_IDP', false),
+    'emulate_idp_url' => '/emulated/idp',
     'emulate_idp_users' => [
         'admin' => [
             'Shib-cn' => 'Admin User',


### PR DESCRIPTION
For the project we are working on, Laravel is in a sub-directory off the main web root. When trying to use the Shibalike functionality, it was failing because the idpUrl was being set to "/emulated/idp". 

All this change does is move that setting up to the config file where I can adjust it.