### PR TITLE
Make emulated idp work in subdirectory

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -38,7 +38,7 @@ class ShibbolethController extends Controller
     {
         if (config('shibboleth.emulate_idp') === true) {
             $this->config = new \Shibalike\Config();
-            $this->config->idpUrl = '/emulated/idp';
+            $this->config->idpUrl = url('/emulated/idp');
 
             $stateManager = $this->getStateManager();
 


### PR DESCRIPTION
We run our instance of laravel in a subdirectory (/courseinfo). When trying to use the Shibalike functionality of this module, we ultimately end up at /emulated/idp and get a 404 (see discussion on my other pull request #2.

This change leverages Laravel's url() function to take account of the sub-directory -- obviating the need for a configuration setting as in #2. 