### PR TITLE
Specify which user model field to authenticate against

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -89,8 +89,10 @@ class ShibbolethController extends Controller
 
         // Attempt to login with the email, if success, update the user model
         // with data from the Shibboleth headers (if present)
-        if (Auth::attempt(array('email' => $map['email']), true)) {
-            $user = $userClass::where('email', '=', $map['email'])->first();
+        //if (Auth::attempt(array(config('shibboleth.authentication_field_shibboleth', 'email') => $map[]), true)) {
+        $authenticationField = config('shibboleth.user_authentication_field', 'email');
+        if (Auth::attempt(array($authenticationField => $map[$authenticationField]), true)) {
+            $user = $userClass::where($authenticationField, '=', $map[$authenticationField])->first();
 
             // Update the model as necessary
             $user->update($map);

--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -87,9 +87,8 @@ class ShibbolethController extends Controller
 
         $userClass = config('auth.providers.users.model', 'App\User');
 
-        // Attempt to login with the email, if success, update the user model
-        // with data from the Shibboleth headers (if present)
-        //if (Auth::attempt(array(config('shibboleth.authentication_field_shibboleth', 'email') => $map[]), true)) {
+        //Attempt to login with the specified field (email by default). If success, update the user model
+        //with data from the Shibboleth headers (if present)
         $authenticationField = config('shibboleth.user_authentication_field', 'email');
         if (Auth::attempt(array($authenticationField => $map[$authenticationField]), true)) {
             $user = $userClass::where($authenticationField, '=', $map[$authenticationField])->first();

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -15,6 +15,7 @@ return [
     'idp_logout' => '/Shibboleth.sso/Logout',
     'authenticated' => '/',
 
+
     /*
     |--------------------------------------------------------------------------
     | Emulate an IdP
@@ -74,8 +75,8 @@ return [
         'email' => 'Shib-mail',
         'emplid' => 'Shib-emplId',
     ],
-
-    //User model attribute to authenticate against
+    
+    //The user model field (from the user array above) that should be used for authentication
     'user_authentication_field' => 'email',
 
     /*

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -75,7 +75,7 @@ return [
         'email' => 'Shib-mail',
         'emplid' => 'Shib-emplId',
     ],
-    
+
     //The user model field (from the user array above) that should be used for authentication
     'user_authentication_field' => 'email',
 

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -75,6 +75,9 @@ return [
         'emplid' => 'Shib-emplId',
     ],
 
+    //User model attribute to authenticate against
+    'user_authentication_field' => 'email',
+
     /*
     |--------------------------------------------------------------------------
     | User Creation and Groups Settings


### PR DESCRIPTION
In the shibboleth.php config file, we have this:

```php
    'user' => [
        // fillable user model attribute => server variable
        'name' => 'Shib-cn',
        'first_name' => 'Shib-givenName',
        'last_name' => 'Shib-sn',
        'email' => 'Shib-mail',
        'emplid' => 'Shib-emplId',
    ],
```

But my organization (JHU) lets users have multiple emails AND the authentication mechanism is by username, not email, so authenticating by email doesn't work for us. We made this tweak to allow someone to specify what field they want to use for authentication. 