### PR TITLE
Fix to allow non standard primary key for model

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Providers/ShibbolethUserProvider.php
+++ b/src/StudentAffairsUwm/Shibboleth/Providers/ShibbolethUserProvider.php
@@ -35,7 +35,10 @@ class ShibbolethUserProvider implements UserProviderInterface
      */
     public function retrieveById($identifier)
     {
-        $user = $this->retrieveByCredentials(['id' => $identifier]);
+        $class = '\\' . ltrim($this->model, '\\');
+        $user = new $class;
+
+        $user = $this->retrieveByCredentials([$user->getKeyName() => $identifier]);
         return ($user && $user->getAuthIdentifier() == $identifier) ?
             $user : null;
     }


### PR DESCRIPTION
This fix allows for a model to have a different primary key than "id".  It will read the primary key of the user model and use that accordingly.